### PR TITLE
Bump pyvcd to support escaped idents for memories

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 const rfc3986_2_0_0 = 'https://files.pythonhosted.org/packages/ff/9a/9afaade874b2fa6c752c36f1548f718b5b83af81ed9b76628329dab81c1b/rfc3986-2.0.0-py2.py3-none-any.whl';
 const jschon_0_11_1 = 'https://files.pythonhosted.org/packages/ce/b1/31f454a2ac0d23b0a47283d115f0af4abe2a1ea391f5ccb223e02d685b82/jschon-0.11.1-py3-none-any.whl';
-const pyvcd_0_4_0 = 'https://files.pythonhosted.org/packages/98/8d/a0d8fb2b9611f3ae22ddc98890b346833fa2c645ad21fd282e61ccdad477/pyvcd-0.4.0-py2.py3-none-any.whl';
+const pyvcd_0_4_1 = 'https://files.pythonhosted.org/packages/8d/6d/24f67ec6cbe90ffca470f3c31e24f3d21124abc5b690398ab34a54bd3070/pyvcd-0.4.1-py2.py3-none-any.whl';
 const amaranth_0_4_2 = 'https://files.pythonhosted.org/packages/27/1c/39881fbd48f9de91d64955f206a7f32fd912d306d18e8c5f74126ee5962f/amaranth-0.4.2-py3-none-any.whl';
 const amaranth_0_4_3 = 'https://files.pythonhosted.org/packages/72/34/82f76a59f4155e26f42cf9f9d04d80befe774aa8af6d9b6e48d3e7b9f060/amaranth-0.4.3-py3-none-any.whl';
 const amaranth_0_4_4 = 'https://files.pythonhosted.org/packages/ee/66/bbb766873059d8051ddb7e760de80beefd286979bc9a786e7ec4ac524336/amaranth-0.4.4-py3-none-any.whl';
@@ -12,16 +12,16 @@ const amaranth_0_5_3 = 'https://files.pythonhosted.org/packages/3a/8d/889014b45e
 const amaranth_0_5_4 = 'https://files.pythonhosted.org/packages/f4/c3/a7124071d8cf2dfc958a13fd6d32efb075ce203d275df8fcbb00cbe82ad7/amaranth-0.5.4-py3-none-any.whl';
 const amaranth_0_5_5 = 'https://files.pythonhosted.org/packages/62/77/79407d18a2130e5bee4a94d19a71c05d36d64d7200ff01c2b024fb0ceda3/amaranth-0.5.5-py3-none-any.whl';
 const pythonPackages = {
-  'v0.5.5': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_5],
-  'v0.5.4': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_4],
-  'v0.5.3': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_3],
-  'v0.5.2': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_2],
-  'v0.5.1': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_1],
-  'v0.5.0': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_0, amaranth_0_5_0],
-  'v0.4.5': [pyvcd_0_4_0, amaranth_0_4_5],
-  'v0.4.4': [pyvcd_0_4_0, amaranth_0_4_4],
-  'v0.4.3': [pyvcd_0_4_0, amaranth_0_4_3],
-  'v0.4.2': [pyvcd_0_4_0, amaranth_0_4_2],
+  'v0.5.5': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_5],
+  'v0.5.4': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_4],
+  'v0.5.3': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_3],
+  'v0.5.2': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_2],
+  'v0.5.1': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_1],
+  'v0.5.0': [rfc3986_2_0_0, jschon_0_11_1, pyvcd_0_4_1, amaranth_0_5_0],
+  'v0.4.5': [pyvcd_0_4_1, amaranth_0_4_5],
+  'v0.4.4': [pyvcd_0_4_1, amaranth_0_4_4],
+  'v0.4.3': [pyvcd_0_4_1, amaranth_0_4_3],
+  'v0.4.2': [pyvcd_0_4_1, amaranth_0_4_2],
 };
 
 const demoCode_0_4 = `\


### PR DESCRIPTION
#4 Part 1/2

I enabled support for memories by bumping the pyvcd version to get [this](https://github.com/SanDisk-Open-Source/pyvcd/commit/baf9acdf42a047fe4d659d1c4e6e23fc12558597). This bump does not seem to break anything to.