### PR TITLE
Fix runCode getting memoized forever in Monaco keybindings.

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -255,14 +255,6 @@ function AppContent() {
   const runCodeRef = useRef(runCode);
   runCodeRef.current = runCode;
 
-  async function shareCode() {
-    setSharingOpen(true);
-    setShareURL('');
-    let fragment = await createShareFragment(amaranthSource, amaranthVersion);
-    let url = new URL('#' + fragment, window.location.href).toString();
-    setShareURL(url);
-  }
-
   const amaranthSourceEditorActions = React.useMemo(() => [
     {
       id: 'amaranth-playground.run',
@@ -270,9 +262,17 @@ function AppContent() {
       keybindings: [
           monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
       ],
-      run: runCodeRef.current,
+      run: () => runCodeRef.current(),
     }
   ], [runCodeRef]);
+
+  async function shareCode() {
+    setSharingOpen(true);
+    setShareURL('');
+    let fragment = await createShareFragment(amaranthSource, amaranthVersion);
+    let url = new URL('#' + fragment, window.location.href).toString();
+    setShareURL(url);
+  }
 
   function tabAndPanel({ key, title, titleStyle = {}, content }) {
     return [


### PR DESCRIPTION
This fixes commit cb9bff1625f0e8d379831288f70e30af73098b16.